### PR TITLE
[bugFix] Fixing white screen on startup on tailing graphical managers

### DIFF
--- a/run.vivado.sh
+++ b/run.vivado.sh
@@ -26,6 +26,7 @@ docker run \
   -v "${PWD}:/work:rw" \
   -e DISPLAY="${DISPLAY}" \
   -e HOME="/work" \
+  -e _JAVA_AWT_WM_NONREPARENTING=1 \
   --net=host \
   xilinx-vivado:${VIVADO_VERSION} \
   /bin/bash -c \


### PR DESCRIPTION
# Issue

When launching Vivado with the provided script, `run.vivado.sh`, a window appears, but the interface never loads (only a white screen). No error appears in the terminal.

# Environment

Host OS: Arch Linux, on Linux archlinux 6.18.7-arch1-1
XDG_SESSION_TYPE=wayland
XDG_CURRENT_DESKTOP=Hyprland
Docker: version 29.2.1, build a5c7197d72
Vivado version: 2025.1

# Proposed fix

This problem doesn't seem to be related with docker, but rather it's a guest OS issue when using a tailing graphical manager. 

A fix has been proposed in [this link](https://adaptivesupport.amd.com/s/question/0D52E00006iHs04SAC/vivado-hangs-forever-with-white-window-during-startup-linux?language=en_US). It consists of adding the following environment variable to the guest OS:
> _JAVA_AWT_WM_NONREPARENTING=1