### PR TITLE
Use bind mount for Vivado archive to optimize Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ times and optimizations.
 
 Approximate durations for key steps:
 
-*   Loading archive into build context: ~30 min
-*   Copying archive into container: ~30 min
+*   Loading archive into build context: ~0 min (skipped due to bind mount)
+*   Copying archive into container: ~0 min (skipped due to bind mount)
 *   Unpacking archive: ~30 min
 *   Vivado installation: ~30 min
 *   Exporting Docker image layers: ~90 min
@@ -143,13 +143,12 @@ the Vivado GUI should launch.
 **Q: Why does the Docker build take so long (several hours)?**
 
 A: The Vivado installer is very large, and the installation process itself is
-complex. Several steps contribute to the long duration: loading the
-multi-gigabyte archive into the build context, copying it within the container,
-unpacking it, running the Vivado installer, and finally exporting the numerous
-layers of the resulting Docker image. Using Docker BuildKit (often enabled by
-default with `make build` or explicitly with `` `DOCKER_BUILDKIT=1 docker build ...` ``)
-is highly recommended as it can optimize some of these steps, but the overall
-process will still be lengthy.
+complex. Several steps contribute to the long duration: unpacking the archive,
+running the Vivado installer, and finally exporting the numerous
+layers of the resulting Docker image. (Note: Using Docker BuildKit with bind mounts,
+as done in this repository, significantly speeds up the process by skipping the
+need to load the multi-gigabyte archive into the build context and copy it into
+the container. This optimization was contributed by @gretel in PR #5). The overall process will still be lengthy.
 
 **Q: The Docker image is over 200GB. Is this normal?**
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,6 +89,7 @@ COPY install_config.txt /tmp/install_config.txt
 # The archive is mounted read-only from the build context — never copied
 # into an image layer. Extraction + install + cleanup happen atomically,
 # so only the final installed files persist.
+# Credit: This bind-mount optimization was contributed by @gretel in PR #5.
 RUN --mount=type=bind,source=${HOST_TOOL_ARCHIVE_NAME},target=/tmp/archive.tar \
     mkdir -p /tmp/vivado-extract \
     && echo "Extracting archive (this takes a while)..." \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Copyright 2023 Google. All rights reserved.
 #
 # Use of this source code is governed by a BSD-style license that can be
@@ -81,24 +82,26 @@ RUN env LANG=en_US.UTF-8 locale-gen --purge en_US.UTF-8 \
 
 RUN mkdir -p $XILINX_INSTALL_LOCATION/tmp
 
-# Copy archive into the container
-COPY $HOST_TOOL_ARCHIVE_NAME $XILINX_INSTALL_LOCATION/tmp
-COPY install_config.txt $XILINX_INSTALL_LOCATION/tmp
-RUN echo --- install_config.txt: \
-    && cat $XILINX_INSTALL_LOCATION/tmp/install_config.txt \
-    && echo ---
+# Copy only the small config file (not the ~96 GB archive!)
+COPY install_config.txt /tmp/install_config.txt
 
-# Unpack the archive locally.
-RUN cd $XILINX_INSTALL_LOCATION/tmp \
-	&& tar -xf $(basename $HOST_TOOL_ARCHIVE_NAME) \
-	&& cd "$XILINX_INSTALL_LOCATION/tmp/`basename --suffix=$HOST_TOOL_ARCHIVE_EXTENSION $HOST_TOOL_ARCHIVE_NAME`"
-
-RUN cd "$XILINX_INSTALL_LOCATION/tmp/`basename --suffix=$HOST_TOOL_ARCHIVE_EXTENSION $HOST_TOOL_ARCHIVE_NAME`" \
-    &&./xsetup --config $XILINX_INSTALL_LOCATION/tmp/install_config.txt \
-		--batch Install \
-		--location /opt/Xilinx \
-		--agree XilinxEULA,3rdPartyEULA \
-	&& rm -fr $XILINX_INSTALL_LOCATION/tmp/*
+# Extract archive and install Vivado in a SINGLE layer using bind mount.
+# The archive is mounted read-only from the build context — never copied
+# into an image layer. Extraction + install + cleanup happen atomically,
+# so only the final installed files persist.
+RUN --mount=type=bind,source=${HOST_TOOL_ARCHIVE_NAME},target=/tmp/archive.tar \
+    mkdir -p /tmp/vivado-extract \
+    && echo "Extracting archive (this takes a while)..." \
+    && tar -xf /tmp/archive.tar -C /tmp/vivado-extract \
+    && echo "Running xsetup batch install..." \
+    && cd /tmp/vivado-extract/$(ls /tmp/vivado-extract) \
+    && ./xsetup \
+        --config /tmp/install_config.txt \
+        --batch Install \
+        --location /opt/Xilinx \
+        --agree XilinxEULA,3rdPartyEULA \
+    && echo "Cleaning up extracted archive..." \
+    && rm -rf /tmp/vivado-extract /tmp/install_config.txt
 
 VOLUME /src
 VOLUME /work


### PR DESCRIPTION
This isolates the bind-mount improvement from #5 by @gretel to avoid copying the large installation archive into the Docker context or creating large layers. It optimizes the Docker image build process and avoids saving the 96GB archive to an intermediate layer. It also includes `# syntax=docker/dockerfile:1` to allow variable expansion in the `--mount=...source=...` parameter, and keeps the location to `/opt/Xilinx`.

---
*PR created automatically by Jules for task [18112264207619893374](https://jules.google.com/task/18112264207619893374) started by @filmil*