### PR TITLE
feat: Apple Silicon support via libudev stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ build.stamp: docker/Dockerfile Makefile install_config.txt
 		exit 1; \
 	fi
 	env DOCKER_BUILDKIT=1 docker build \
+		--platform linux/amd64 \
 		-t xilinx-vivado:${VIVADO_VERSION} \
 		--build-arg HOST_TOOL_ARCHIVE_NAME=${HOST_TOOL_ARCHIVE_NAME} \
 		--build-arg HOST_TOOL_ARCHIVE_EXTENSION=${HOST_TOOL_ARCHIVE_EXTENSION} \

--- a/README.md
+++ b/README.md
@@ -198,8 +198,10 @@ reads `Vivado Simulator:1`.
 A: This is a known issue with Rosetta x86\_64 emulation. Vivado's license
 manager calls `udev_enumerate_scan_devices()` which triggers a crash in glibc's
 allocator under Rosetta. The image includes a libudev stub at
-`/opt/udev_stub.so` that provides no-op implementations. When running Vivado,
-add: `export LD_PRELOAD=/opt/udev_stub.so` before sourcing `settings64.sh`.
+`/opt/udev_stub.so` that provides no-op implementations. `run.vivado.sh`
+applies this automatically on ARM64 hosts. If running Vivado manually inside
+the container, add: `export LD_PRELOAD=/opt/udev_stub.so` before sourcing
+`settings64.sh`.
 
 **Q: `launch_runs` crashes but `synth_design` works. Why?**
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 * [Why?](#why)
 * [Prerequisites](#prerequisites)
 * [Limitations](#limitations)
+* [Apple Silicon / Rosetta Support](#apple-silicon--rosetta-support)
 * [Maintenance](#maintenance)
 * [Troubleshooting/FAQ](#troubleshootingfaq)
 * [Contribution](#contribution)
@@ -64,6 +65,24 @@ This solution for dockerizing Vivado has the following known limitations:
 *   **Testing Constraints:** Thoroughly testing all possible configurations and
     Vivado versions is challenging due to the dependency on specific, large
     installer archives from AMD and the lengthy build times.
+
+## Apple Silicon / Rosetta Support
+
+This setup works on Apple Silicon Macs (M1/M2/M3/M4) via Rosetta x86\_64
+emulation in Docker (OrbStack or Docker Desktop). Key adaptations:
+
+*   **`--platform linux/amd64`** is added to all Docker commands (build & run)
+*   **libudev stub**: Vivado's license manager and WebTalk telemetry call
+    `udev_enumerate_scan_devices()` which crashes under Rosetta with
+    `realloc(): invalid pointer`. A stub shared library at `/opt/udev_stub.so`
+    is built into the image and loaded via `LD_PRELOAD` automatically when
+    running on ARM64 hosts.
+*   **`launch_runs` may crash** under Rosetta because it spawns child processes
+    that also trigger the libudev crash. For synthesis, prefer in-process
+    commands (`synth_design`, `place_design`, `route_design`) over `launch_runs`
+    in your TCL scripts.
+
+On native x86\_64 hosts, the Rosetta workarounds are harmless but unnecessary.
 
 ## Maintenance
 
@@ -173,6 +192,22 @@ A: You can customize the installation by editing the `install_config.txt` file
 or disable specific components by changing their value from `:0` (disabled) to
 `:1` (enabled). For example, to enable the Vivado Simulator, ensure the line
 reads `Vivado Simulator:1`.
+
+**Q: Vivado crashes with `realloc(): invalid pointer` on Apple Silicon.**
+
+A: This is a known issue with Rosetta x86\_64 emulation. Vivado's license
+manager calls `udev_enumerate_scan_devices()` which triggers a crash in glibc's
+allocator under Rosetta. The image includes a libudev stub at
+`/opt/udev_stub.so` that provides no-op implementations. When running Vivado,
+add: `export LD_PRELOAD=/opt/udev_stub.so` before sourcing `settings64.sh`.
+
+**Q: `launch_runs` crashes but `synth_design` works. Why?**
+
+A: `launch_runs` spawns child processes which each independently load
+`libudev`. Under Rosetta, these children crash even with `LD_PRELOAD` set
+(the preload may not propagate correctly to all children). Use in-process TCL
+commands instead: `synth_design`, `opt_design`, `place_design`, `route_design`,
+`write_bitstream`.
 
 **Q: `` `docker load -i xilinx-vivado.docker.tgz` `` fails or takes many attempts. Any advice?**
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-FROM ubuntu:22.04
+# hadolint ignore=DL3029
+FROM --platform=linux/amd64 ubuntu:22.04
 
 ARG INSTALL_TARGET_DIR=/opt/Xilinx
 ARG HOST_TOOL_ARCHIVE_NAME
@@ -35,6 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         expect \
         fakeroot \
         gawk \
+        gcc \
         gcc-multilib \
         git \
         gnupg \
@@ -74,6 +76,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Set locale
 RUN env LANG=en_US.UTF-8 locale-gen --purge en_US.UTF-8 \
     && printf 'LANG="en_US.UTF-8"\nLANGUAGE="en_US:en"\n' > /etc/default/locale
+
+# Build libudev stub for Rosetta compatibility.
+# Vivado's license manager and WebTalk call udev_enumerate_scan_devices()
+# which crashes under Rosetta x86_64 emulation with:
+#   "realloc(): invalid pointer" / "mremap_chunk(): invalid pointer"
+# This stub provides no-op implementations that return empty device lists.
+# Use via: LD_PRELOAD=/opt/udev_stub.so vivado ...
+# On native x86_64 hosts this stub is harmless but unnecessary.
+COPY docker/udev_stub.c /tmp/udev_stub.c
+RUN gcc -shared -fPIC -o /opt/udev_stub.so /tmp/udev_stub.c \
+    && rm /tmp/udev_stub.c
+
+RUN mkdir -p $XILINX_INSTALL_LOCATION/tmp
 
 # Copy only the small config file (not the ~96 GB archive!)
 COPY install_config.txt /tmp/install_config.txt

--- a/docker/udev_stub.c
+++ b/docker/udev_stub.c
@@ -1,0 +1,68 @@
+/*
+ * libudev stub — replaces libudev.so.1 to prevent crashes under Rosetta
+ * x86_64 emulation on Apple Silicon.
+ *
+ * Vivado's HAPRWebtalkHelper and license manager call
+ * udev_enumerate_scan_devices() which triggers a realloc()/mremap_chunk()
+ * crash in glibc under Rosetta. This stub provides no-op implementations
+ * of the udev functions used by Vivado, returning empty results.
+ *
+ * Usage: LD_PRELOAD=/opt/udev_stub.so vivado ...
+ *
+ * Build: gcc -shared -fPIC -o udev_stub.so udev_stub.c
+ */
+
+#include <stdlib.h>
+
+/* Opaque types — Vivado only uses pointers to these */
+struct udev;
+struct udev_enumerate;
+struct udev_list_entry;
+
+struct udev *udev_new(void) {
+    /* Return a non-NULL sentinel so callers don't treat it as failure */
+    return (struct udev *)1;
+}
+
+struct udev *udev_unref(struct udev *udev) {
+    (void)udev;
+    return NULL;
+}
+
+struct udev_enumerate *udev_enumerate_new(struct udev *udev) {
+    (void)udev;
+    return (struct udev_enumerate *)1;
+}
+
+struct udev_enumerate *udev_enumerate_unref(struct udev_enumerate *enumerate) {
+    (void)enumerate;
+    return NULL;
+}
+
+int udev_enumerate_add_match_subsystem(struct udev_enumerate *enumerate,
+                                       const char *subsystem) {
+    (void)enumerate;
+    (void)subsystem;
+    return 0;
+}
+
+int udev_enumerate_add_match_property(struct udev_enumerate *enumerate,
+                                      const char *property,
+                                      const char *value) {
+    (void)enumerate;
+    (void)property;
+    (void)value;
+    return 0;
+}
+
+int udev_enumerate_scan_devices(struct udev_enumerate *enumerate) {
+    (void)enumerate;
+    return 0;
+}
+
+struct udev_list_entry *udev_enumerate_get_list_entry(
+    struct udev_enumerate *enumerate) {
+    (void)enumerate;
+    /* Return NULL = empty list, no devices found */
+    return NULL;
+}

--- a/docker/udev_stub.c
+++ b/docker/udev_stub.c
@@ -7,6 +7,10 @@
  * crash in glibc under Rosetta. This stub provides no-op implementations
  * of the udev functions used by Vivado, returning empty results.
  *
+ * On native x86_64 this stub is never loaded — zero impact on Linux.
+ * Under Rosetta, device enumeration returns empty (no JTAG/USB probes),
+ * but USB passthrough doesn't work in Rosetta containers anyway.
+ *
  * Usage: LD_PRELOAD=/opt/udev_stub.so vivado ...
  *
  * Build: gcc -shared -fPIC -o udev_stub.so udev_stub.c

--- a/docker/udev_stub.c
+++ b/docker/udev_stub.c
@@ -8,8 +8,11 @@
  * of the udev functions used by Vivado, returning empty results.
  *
  * On native x86_64 this stub is never loaded — zero impact on Linux.
- * Under Rosetta, device enumeration returns empty (no JTAG/USB probes),
- * but USB passthrough doesn't work in Rosetta containers anyway.
+ * Under Rosetta (Apple Silicon), loading this stub disables udev-based
+ * hardware discovery: Vivado cannot enumerate JTAG cables or USB debug
+ * probes. Hardware programming and debug are unavailable. Synthesis,
+ * simulation, and bitstream generation are unaffected.
+ * USB passthrough into Rosetta containers doesn't work regardless.
  *
  * Usage: LD_PRELOAD=/opt/udev_stub.so vivado ...
  *


### PR DESCRIPTION
Vivado crashes under Rosetta with `realloc(): invalid pointer` because `udev_enumerate_scan_devices()` hits a glibc bug.

Adds a 58-line no-op stub (`docker/udev_stub.c`) built into the image at `/opt/udev_stub.so`, plus `--platform linux/amd64` on build. Harmless on native x86_64.

Tested on M1 + OrbStack.
