### PR TITLE
feat: generalize run.vivado.sh for batch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,27 @@ Once the image is loaded into Docker, start Vivado using:
 make run
 ```
 
-If you are on a system with a graphical interface (X11 forwarding configured),
-the Vivado GUI should launch.
+Or use `run.vivado.sh` directly with environment overrides:
+
+```bash
+# Interactive TCL console
+VIVADO_CMD="vivado -mode tcl" ./run.vivado.sh
+
+# Batch synthesis
+SRC_DIR=/path/to/fpga/project WORK_DIR=/path/to/output \
+  VIVADO_CMD="vivado -mode batch -source /src/build.tcl" \
+  ./run.vivado.sh
+```
+
+**`run.vivado.sh` environment variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VIVADO_VERSION` | `2025.2` | Vivado version to use |
+| `SRC_DIR` | current directory | Host directory mounted at `/src` |
+| `WORK_DIR` | current directory | Host directory mounted at `/work` |
+| `VIVADO_CMD` | `vivado` (GUI) | Command to run inside container |
+| `ROSETTA` | auto-detect | Set to `1` to force libudev stub |
 
 ## Troubleshooting/FAQ
 

--- a/run.vivado.sh
+++ b/run.vivado.sh
@@ -1,37 +1,66 @@
-#! /bin/bash
+#!/bin/bash
 # Copyright 2023 Google. All rights reserved.
 #
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
-
-# A script that runs the graphical vivado tool from within the built container.
+#
+# Runs Vivado inside the Docker container. Supports both interactive (GUI/TCL)
+# and batch modes.
+#
+# Environment variables:
+#   VIVADO_VERSION  Vivado version (default: 2025.2)
+#   SRC_DIR         Host directory to mount at /src (default: current dir)
+#   WORK_DIR        Host directory to mount at /work (default: current dir)
+#   VIVADO_CMD      Command to run (default: interactive Vivado GUI)
+#                   Example for batch: VIVADO_CMD="vivado -mode batch -source /src/build.tcl"
+#   ROSETTA         Set to "1" to enable libudev stub for Apple Silicon
+#                   (default: auto-detect via uname -m)
 
 set -euo pipefail
 set -x
 
-INTERACTIVE=""
+INTERACTIVE=()
 if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then
-	# Only add these if running on actual terminal.
-	INTERACTIVE="--interactive --tty"
+	INTERACTIVE=(--interactive --tty)
 fi
 
-VIVADO_VERSION="2025.1"
+VIVADO_VERSION="${VIVADO_VERSION:-2025.2}"
+VIVADO_PATH="/opt/Xilinx/${VIVADO_VERSION}/Vivado"
 
-readonly VIVADO_PATH="/opt/Xilinx/${VIVADO_VERSION}/Vivado"
+# Paths — override via environment if needed
+SRC_DIR="${SRC_DIR:-$(pwd)}"
+WORK_DIR="${WORK_DIR:-$(pwd)}"
+
+mkdir -p "${WORK_DIR}"
+
+# Auto-detect Rosetta (Apple Silicon running x86_64 container)
+if [[ -z "${ROSETTA:-}" ]]; then
+  if [[ "$(uname -m)" == "arm64" ]]; then
+    ROSETTA=1
+  else
+    ROSETTA=0
+  fi
+fi
+
+# Build the preload string for Rosetta workaround
+PRELOAD_CMD=""
+if [[ "${ROSETTA}" == "1" ]]; then
+  PRELOAD_CMD="export LD_PRELOAD=/opt/udev_stub.so && "
+fi
+
+# Default: interactive Vivado. Override VIVADO_CMD for batch mode.
+# For batch synthesis: VIVADO_CMD="vivado -mode batch -source /src/build.tcl"
+VIVADO_CMD="${VIVADO_CMD:-vivado}"
 
 docker run \
-  ${INTERACTIVE} \
-  -u $(id -u):$(id -g) \
-  -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
-  -v "${PWD}:/work:rw" \
-  -e DISPLAY="${DISPLAY}" \
+  --platform linux/amd64 \
+  "${INTERACTIVE[@]}" \
+  --rm \
+  -v "${SRC_DIR}:/src:rw" \
+  -v "${WORK_DIR}:/work:rw" \
   -e HOME="/work" \
-  -e _JAVA_AWT_WM_NONREPARENTING=1 \
-  --net=host \
-  xilinx-vivado:${VIVADO_VERSION} \
+  -e DISPLAY="${DISPLAY:-}" \
+  -e XILINX_LOCAL_USER_DATA=no \
+  "xilinx-vivado:${VIVADO_VERSION}" \
   /bin/bash -c \
-    "env \
-      LD_LIBRARY_PATH=${VIVADO_PATH}/lib/lnx64.o \
-      ${VIVADO_PATH}/bin/setEnvAndRunCmd.sh vivado \
-    "
-
+    "${PRELOAD_CMD}source ${VIVADO_PATH}/settings64.sh && cd /work && ${VIVADO_CMD}"

--- a/run.vivado.sh
+++ b/run.vivado.sh
@@ -52,14 +52,26 @@ fi
 # For batch synthesis: VIVADO_CMD="vivado -mode batch -source /src/build.tcl"
 VIVADO_CMD="${VIVADO_CMD:-vivado}"
 
+# Conditional docker flags for platform differences
+DOCKER_ARGS=()
+if [[ -d /tmp/.X11-unix ]]; then
+  DOCKER_ARGS+=(-v /tmp/.X11-unix:/tmp/.X11-unix:ro)
+fi
+if [[ "$(uname -s)" == "Linux" ]]; then
+  DOCKER_ARGS+=(--net=host)
+fi
+
 docker run \
   --platform linux/amd64 \
   "${INTERACTIVE[@]}" \
   --rm \
+  -u "$(id -u):$(id -g)" \
+  "${DOCKER_ARGS[@]}" \
   -v "${SRC_DIR}:/src:rw" \
   -v "${WORK_DIR}:/work:rw" \
   -e HOME="/work" \
   -e DISPLAY="${DISPLAY:-}" \
+  -e _JAVA_AWT_WM_NONREPARENTING=1 \
   -e XILINX_LOCAL_USER_DATA=no \
   "xilinx-vivado:${VIVADO_VERSION}" \
   /bin/bash -c \


### PR DESCRIPTION
Makes `run.vivado.sh` configurable via environment variables: `VIVADO_CMD`, `SRC_DIR`, `WORK_DIR`, `ROSETTA`. Supports batch synthesis and auto-detects Apple Silicon for the libudev workaround.
