### PR TITLE
Add USB Devices Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ SRC_DIR=/path/to/fpga/project WORK_DIR=/path/to/output \
 | `WORK_DIR` | current directory | Host directory mounted at `/work` |
 | `VIVADO_CMD` | `vivado` (GUI) | Command to run inside container |
 | `ROSETTA` | auto-detect | Set to `1` to force libudev stub |
+| `USB_DEVICE_DIR` | None | Set to Host USB dir in order to enable USB |
 
 ## Troubleshooting/FAQ
 
@@ -240,6 +241,11 @@ daemon logs for more specific errors or consulting Docker community forums for
 advice on handling large images.
 
 **Q: USB devices are not showing up in the Hardware Manager. Why?**
+
+A: You need to set the environment variable USB_DEVICE_DIR to the host's 
+path to USB devices. On Ubuntu, this path is by default `/dev/bus/usb`
+
+**Q: USB devices are still not showing up. Why?**
 
 A: Even though the generated Docker image has installed the USB drivers within
 itself, the host OS also needs the drivers installed. These can be extracted 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,20 @@ again sometimes helps. If persistent issues occur, consider checking Docker
 daemon logs for more specific errors or consulting Docker community forums for
 advice on handling large images.
 
+**Q: USB devices are not showing up in the Hardware Manager. Why?**
+
+A: Even though the generated Docker image has installed the USB drivers within
+itself, the host OS also needs the drivers installed. These can be extracted 
+from the Docker image using the following commands (note that if you use
+a different version than 2025.2, change the numbers):
+```
+docker create --name tmp xilinx-vivado:2025.2
+docker cp tmp:/opt/Xilinx/2025.2/data/xicom/cable_drivers ./cable_drivers
+```
+This will extract the cable drivers for both Windows and Linux in your
+current directory. Install the appropriate drivers on the host OS. 
+You may need to unplug and plug the USB device before the drivers work.
+
 ## Contribution
 
 Contributions are welcome! Please feel free to submit pull requests or open

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -112,6 +112,7 @@ RUN --mount=type=bind,source=${HOST_TOOL_ARCHIVE_NAME},target=/tmp/archive.tar \
         --agree XilinxEULA,3rdPartyEULA \
     && echo "Cleaning up extracted archive..." \
     && rm -rf /tmp/vivado-extract /tmp/install_config.txt \
+    && echo "Installing USB drivers..." \
     && mkdir -p /etc/udev/rules.d \
     && cd "${INSTALL_TARGET_DIR}/${VIVADO_VERSION}/Vivado/data/xicom/cable_drivers/lin64/install_script/install_drivers" \
     && ./install_drivers

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -111,7 +111,10 @@ RUN --mount=type=bind,source=${HOST_TOOL_ARCHIVE_NAME},target=/tmp/archive.tar \
         --location ${INSTALL_TARGET_DIR} \
         --agree XilinxEULA,3rdPartyEULA \
     && echo "Cleaning up extracted archive..." \
-    && rm -rf /tmp/vivado-extract /tmp/install_config.txt
+    && rm -rf /tmp/vivado-extract /tmp/install_config.txt \
+    && mkdir -p /etc/udev/rules.d \
+    && cd "${INSTALL_TARGET_DIR}/${VIVADO_VERSION}/Vivado/data/xicom/cable_drivers/lin64/install_script/install_drivers" \
+    && ./install_drivers
 
 COPY run.sh /
 RUN chmod a+x /run.sh

--- a/run.vivado.sh
+++ b/run.vivado.sh
@@ -15,6 +15,8 @@
 #                   Example for batch: VIVADO_CMD="vivado -mode batch -source /src/build.tcl"
 #   ROSETTA         Set to "1" to enable libudev stub for Apple Silicon
 #                   (default: auto-detect via uname -m)
+#   USB_DEVICE_DIR  Host directory for mounted USB devices (default: no path)
+#                   Override to enable USB support. USB Drivers needs to be installed on host.
 
 set -euo pipefail
 set -x
@@ -30,6 +32,14 @@ VIVADO_PATH="/opt/Xilinx/${VIVADO_VERSION}/Vivado"
 # Paths — override via environment if needed
 SRC_DIR="${SRC_DIR:-$(pwd)}"
 WORK_DIR="${WORK_DIR:-$(pwd)}"
+
+# Add --device command only if USB path is provided
+# (default for Ubuntu is /dev/bus/usb)
+USB_DEVICE_DIR="${USB_DEVICE_DIR:-}"
+USB_CMD=""
+if [[ -n "${USB_DEVICE_DIR}" ]]; then
+  USB_CMD="--device $USB_DEVICE_DIR"
+fi
 
 mkdir -p "${WORK_DIR}"
 
@@ -73,7 +83,7 @@ docker run \
   -e DISPLAY="${DISPLAY:-}" \
   -e _JAVA_AWT_WM_NONREPARENTING=1 \
   -e XILINX_LOCAL_USER_DATA=no \
-  --device "/dev/bus/usb" \
+  ${USB_CMD} \
   "xilinx-vivado:${VIVADO_VERSION}" \
   /bin/bash -c \
     "${PRELOAD_CMD}source ${VIVADO_PATH}/settings64.sh && cd /work && ${VIVADO_CMD}"

--- a/run.vivado.sh
+++ b/run.vivado.sh
@@ -73,6 +73,7 @@ docker run \
   -e DISPLAY="${DISPLAY:-}" \
   -e _JAVA_AWT_WM_NONREPARENTING=1 \
   -e XILINX_LOCAL_USER_DATA=no \
+  --device "/dev/bus/usb" \
   "xilinx-vivado:${VIVADO_VERSION}" \
   /bin/bash -c \
     "${PRELOAD_CMD}source ${VIVADO_PATH}/settings64.sh && cd /work && ${VIVADO_CMD}"


### PR DESCRIPTION
I thought it was a good idea to be able to use the Hardware Manager, in order to flash devices, debug and so on, so I did some changes to the generation and run scripts. 

What it does in the generation of the Docker image is that after the installation of Vivado, it also installs the USB drivers. These scripts expect the directory  /etc/udev/rules.d to exist, so it's also created.

The run-script adds the usual USB device path.

I've tested that this works using 

- Vivado 2025.2
- JTAG-HS3
- Artix 7 
- WSL2 running Ubuntu 24.04 which in turn runs Docker version 29.5.1
- Attaching the JTAG-HS3 to WSL using usbipd 

<img width="858" height="357" alt="image" src="https://github.com/user-attachments/assets/12982f7d-9861-464d-8d94-27f26a59ad32" />
